### PR TITLE
fix: adjust GetByCNPJ to return nil instead of error when document no…

### DIFF
--- a/internal/repository/mongorepo/mongo_repository.go
+++ b/internal/repository/mongorepo/mongo_repository.go
@@ -62,6 +62,9 @@ func (r *mongoRepository) GetByCNPJ(ctx context.Context, cnpj string) (*domain.C
 	var company domain.Company
 	err := r.collection.FindOne(ctx, bson.M{"cnpj": cnpj}).Decode(&company)
 	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return &company, nil


### PR DESCRIPTION
…t found

- Changed GetByCNPJ to return (nil, nil) when no document is found
- Only return actual errors for real database issues (timeout, connection)
- This fixes the 500 error when cheking for non-existing CNPJ
- Now properly distinguishes between 'not found' and 'database error'